### PR TITLE
Fix game order dependency issue (v2.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,66 @@ Here is an easy example about how to use the package:
 
 To learn more about the detailed usage, please refer to the docstrings of [`whr.Base`](https://github.com/wind23/whole_history_rating/blob/master/whr/base.py) and [`whr.Evaluate`](https://github.com/wind23/whole_history_rating/blob/master/whr/evaluate.py).
 
+## Running Tests
+
+To run the test suite:
+
+```bash
+python tests/test_whr.py
+```
+
+Or using pytest:
+
+```bash
+pytest tests/test_whr.py -v
+```
+
+## API Reference
+
+### whr.Base
+
+Main class for computing Whole History Ratings.
+
+**Constructor:**
+- `whr.Base(w2=300, virtual_games=2)`: Initialize the rating system
+  - `w2`: Variance parameter controlling rating volatility over time
+  - `virtual_games`: Number of virtual draws added to first day for regularization
+
+**Methods:**
+- `create_game(black, white, winner, time_step, handicap=0)`: Add a single game
+  - `black`: Name of the black player
+  - `white`: Name of the white player
+  - `winner`: "B" (black wins), "W" (white wins), or "D" (draw)
+  - `time_step`: Integer representing the time period (e.g., day number)
+  - `handicap`: Optional handicap value (default 0)
+
+- `create_games(games)`: Add multiple games at once
+  - `games`: List of game records, each in format `[black, white, winner, time_step, handicap]`
+
+- `iterate(count)`: Run Newton's method iterations
+  - `count`: Number of iterations to perform (typically 50-100)
+
+- `iterate_until_converge(verbose=True)`: Iterate until convergence
+  - Returns the number of iterations performed
+
+- `ratings_for_player(name)`: Get rating history for a player
+  - Returns list of `[time_step, rating, uncertainty]` for each time period
+
+- `get_ordered_ratings()`: Get all players' ratings ordered by final rating
+
+- `log_likelihood()`: Get the log-likelihood of the current model
+
+### whr.Evaluate
+
+Class for evaluating prediction accuracy on test data.
+
+**Constructor:**
+- `whr.Evaluate(base)`: Initialize evaluator with a fitted WHR model
+
+**Methods:**
+- `get_rating(name, time_step, ignore_null_players=True)`: Get a player's rating at a specific time
+- `evaluate_ave_log_likelihood_games(games, ignore_null_players=True)`: Compute average log-likelihood on test games
+
 ## References
 
 Rémi Coulom. [Whole-history rating: A Bayesian rating system for players of time-varying strength](https://www.remi-coulom.fr/WHR/WHR.pdf). In _International Conference on Computers and Games_. 2008.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, glob
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 
-__version__ = "2.0.4"
+__version__ = "2.1.0"
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text(encoding="utf-8")

--- a/src/base.cc
+++ b/src/base.cc
@@ -179,8 +179,10 @@ int Base::iterate_until_coverge(bool verbose) {
     run_one_iteration();
     count++;
   }
-  for (auto &player : players_) {
-    player.second->update_uncertainty();
+  std::vector<std::string> sorted_player_names = players_order_;
+  std::sort(sorted_player_names.begin(), sorted_player_names.end());
+  for (const std::string &name : sorted_player_names) {
+    players_[name]->update_uncertainty();
   }
   return count;
 }
@@ -189,13 +191,17 @@ void Base::iterate(int count) {
   for (int i = 0; i < count; i++) {
     run_one_iteration();
   }
-  for (auto &player : players_) {
-    player.second->update_uncertainty();
+  std::vector<std::string> sorted_player_names = players_order_;
+  std::sort(sorted_player_names.begin(), sorted_player_names.end());
+  for (const std::string &name : sorted_player_names) {
+    players_[name]->update_uncertainty();
   }
 }
 
 void Base::run_one_iteration() {
-  for (const std::string &name : players_order_) {
+  std::vector<std::string> sorted_players = players_order_;
+  std::sort(sorted_players.begin(), sorted_players.end());
+  for (const std::string &name : sorted_players) {
     players_[name]->run_one_newton_iteration();
   }
 }

--- a/tests/test_whr.py
+++ b/tests/test_whr.py
@@ -32,11 +32,33 @@ class WholeHistoryRatingTest:
         test_log_likelihood = evaluate.evaluate_ave_log_likelihood_games(test_games)
         assert round(test_log_likelihood * 100000) == -50215
 
+    def test_game_order_independence(self):
+        whr1 = whr.Base()
+        whr1.create_game("alice", "bob", "W", 1, 0)
+        whr1.create_game("alice", "bob", "B", 2, 0)
+        whr1.create_game("alice", "bob", "W", 3, 0)
+        whr1.iterate(50)
+
+        whr2 = whr.Base()
+        whr2.create_game("alice", "bob", "W", 3, 0)
+        whr2.create_game("alice", "bob", "B", 2, 0)
+        whr2.create_game("alice", "bob", "W", 1, 0)
+        whr2.iterate(50)
+
+        ratings1_alice = sorted(whr1.ratings_for_player("alice"), key=lambda x: x[0])
+        ratings2_alice = sorted(whr2.ratings_for_player("alice"), key=lambda x: x[0])
+        ratings1_bob = sorted(whr1.ratings_for_player("bob"), key=lambda x: x[0])
+        ratings2_bob = sorted(whr2.ratings_for_player("bob"), key=lambda x: x[0])
+
+        assert ratings1_alice == ratings2_alice
+        assert ratings1_bob == ratings2_bob
+
 
 def test_whr_class():
     whrt = WholeHistoryRatingTest()
     whrt.test_output()
     whrt.test_evaluate()
+    whrt.test_game_order_independence()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Fix Player::add_game() to support adding games in any order using binary search
- Fix iteration order to be deterministic by sorting player names alphabetically
- Add test_game_order_independence() to verify order-independent behavior
- Update README.md with API reference and testing instructions
- Bump version to 2.1.0

Games can now be added in any order and will produce identical results. The algorithm automatically maintains correct temporal ordering internally.

Fixes #10