### PR TITLE
test: suppress unhandled warnings in test_load_csv_positional_fallback

### DIFF
--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -56,8 +56,15 @@ Bob,Dave,B,10,0.0
 """
     f = io.StringIO(csv_data)
     
-    with pytest.warns(UserWarning, match="No CSV header detected. Falling back to default column order"):
+    # We expect multiple warnings because the header row is treated as data and contains invalid values
+    with pytest.warns(UserWarning) as record:
         base.load_csv(f)
+
+    messages = [w.message.args[0] for w in record]
+    assert any("No CSV header detected. Falling back to default column order" in msg for msg in messages)
+    assert any("Invalid winner 'ThirdHeader'" in msg for msg in messages)
+    assert any("Invalid time_step 'FourthHeader'" in msg for msg in messages)
+    assert any("Invalid handicap 'FifthHeader'" in msg for msg in messages)
 
     assert len(base.ratings_for_player("Alice")) == 1
     assert len(base.ratings_for_player("Bob")) == 1


### PR DESCRIPTION
## Summary
This Pull Request cleans up the `pytest` output warnings summary by fully capturing and asserting all expected `UserWarning`s in `test_load_csv_positional_fallback`.

## Details
In `test_load_csv_positional_fallback`, the test file feeds an unrecognized header row (`SomeHeader,AnotherHeader,...`) which causes the parser to fall back to positional mode and treat this row as raw game data. 

Since the values in the header row are not valid game attributes (e.g. invalid winner or time_step), the library correctly generates multiple invalid-value warnings. However, because they weren't explicitly captured by `pytest.warns` in the test case, they leaked into the console's terminal warning summary.

This fix:
- Captures all emitted `UserWarning`s in a warning record.
- Asserts on each specific fallback and value error warning.
- Ensures a completely clean console test output (zero warnings printed in summary).
